### PR TITLE
.gitignore: Ignore docs/api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Production
 /build
+/docs/api
 
 # Generated files
 .docusaurus


### PR DESCRIPTION
These are always built during GH Actions workflows. There is no reason to track changes on these files. Caveat: They must be generated to make a new version of the docs, since we can't re-generate docs for all versioned apis every time we change the site.